### PR TITLE
Add a sample JUnit test to the g8 template

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,3 +1,4 @@
 scalaVersion := "3.0.0"
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
+libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
 enablePlugins(JettyPlugin)

--- a/src/main/g8/src/test/scala/Http.scala
+++ b/src/main/g8/src/test/scala/Http.scala
@@ -1,0 +1,64 @@
+import java.net._
+import scala.collection.JavaConverters._
+import scala.io.Source
+
+case class Response(
+  status: Int,
+  headers: Map[String, String],
+  body: String
+)
+
+object Request {
+
+  def apply(
+    method: String,
+    url: String,
+    headers: Map[String, String],
+    body: Option[String]
+  ): Response = {
+
+    val c =
+      new URL(url)
+        .openConnection()
+        .asInstanceOf[HttpURLConnection]
+
+    c.setInstanceFollowRedirects(false)    
+    c.setRequestMethod(method)
+    c.setDoInput(true)
+    c.setDoOutput(body.isDefined)
+
+    headers foreach { case (k, v) =>
+      c.setRequestProperty(k, v)
+    }
+
+    body foreach { b =>
+      c.getOutputStream.write(b.getBytes("UTF-8"))
+    }
+
+    val response =
+      Response(
+        status = c.getResponseCode(),
+        headers =
+          c
+            .getHeaderFields()
+            .asScala
+            .filter({ case (k, _) => k != null })
+            .map({ case (k, v) => (k, v.asScala.mkString(",")) })
+            .toMap - "Date" - "Content-Length" - "Server",
+        body =
+          Source
+            .fromInputStream {
+              if (c.getResponseCode() < 400) {
+                c.getInputStream
+              } else {
+                c.getErrorStream
+              }
+            }
+            .mkString
+      )
+
+    c.disconnect()
+
+    response
+  }
+}

--- a/src/main/g8/src/test/scala/TestSuite.scala
+++ b/src/main/g8/src/test/scala/TestSuite.scala
@@ -1,0 +1,21 @@
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TestSuite {
+
+  @Test
+  def getRoot(): Unit = {
+    assertEquals(
+        Response( 200
+                , Map("Content-Type" -> "text/html;charset=utf-8")
+                , body = 
+                    """|<html>
+                       |  <body>
+                       |    <h1>Hello, world!</h1>
+                       |  </body>
+                       |</html>""".stripMargin
+                )
+      , Request("GET", "http://localhost:8080/", Map.empty, None) 
+    )
+  }
+}

--- a/src/test/g8/test
+++ b/src/test/g8/test
@@ -1,0 +1,1 @@
+> jetty:test


### PR DESCRIPTION
This provides an example test (using JUnit) for new projects, allowing
the use of `jetty:test`.