### PR TITLE
Fix a deprecation warning from sbt 1.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "xsbt-web-plugin Template Project",
     scalaVersion := "2.12.11",
-    test in Test := {
+    Test / test := {
       val _ = (g8Test in Test).toTask("").value
     },
     scriptedLaunchOpts ++= List("-Xms1024m", "-Xmx1024m", "-XX:ReservedCodeCacheSize=128m", "-Xss2m", "-Dfile.encoding=UTF-8"),


### PR DESCRIPTION
This uses the newer slash syntax to eliminate an sbt warning:

```
xsbt-web-plugin.g8/build.sbt:9: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
    test in Test := {
```