### PR TITLE
Migrate to sbt's slash syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file("."))
     name := "xsbt-web-plugin Template Project",
     scalaVersion := "2.12.14",
     Test / test := {
-      val _ = (g8Test in Test).toTask("").value
+      val _ = (Test / g8Test).toTask("").value
     },
     scriptedLaunchOpts ++= List("-Xms1024m", "-Xmx1024m", "-XX:ReservedCodeCacheSize=128m", "-Xss2m", "-Dfile.encoding=UTF-8"),
     resolvers += Resolver.url("typesafe", url("https://repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)


### PR DESCRIPTION
This migrates from sbt's `in` syntax to slash syntax, fixing the
following warning:

```
build.sbt:10: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
      val _ = (g8Test in Test).toTask("").value
```