### PR TITLE
Drop the unused sbt scripted plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,5 @@ lazy val root = (project in file("."))
     Test / test := {
       val _ = (Test / g8Test).toTask("").value
     },
-    scriptedLaunchOpts ++= List("-Xms1024m", "-Xmx1024m", "-XX:ReservedCodeCacheSize=128m", "-Xss2m", "-Dfile.encoding=UTF-8"),
     resolvers += Resolver.url("typesafe", url("https://repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
 addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.13.1")
-libraryDependencies += { "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value }


### PR DESCRIPTION
The scripted-plugin isn't needed, and prevents updating to Scala 2.13.
Unblocks #38.