### PR TITLE
scala-library: 2.12.18 -> 2.12.19

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file("."))
   .enablePlugins(ScriptedPlugin)
   .settings(
     name := "xsbt-web-plugin Template Project",
-    scalaVersion := "2.12.18",
+    scalaVersion := "2.12.19",
     Test / test := {
       val _ = (Test / g8Test).toTask("").value
     },


### PR DESCRIPTION
📦 Updates [org.scala-lang:scala-library](https://github.com/scala/scala) from `2.12.18` to `2.12.19`

📜 [GitHub Release Notes](https://github.com/scala/scala/releases/tag/v2.12.19) - [Version Diff](https://github.com/scala/scala/compare/v2.12.18...v2.12.19)